### PR TITLE
Correct misplaced doc strings and deftest duplicate name

### DIFF
--- a/src/archimedes/core.clj
+++ b/src/archimedes/core.clj
@@ -114,11 +114,11 @@
 (defn get-feature
   "Gets the value of the feature for a graph."
   [s]
-  (get ^Map (get-features) s))
+  (get ^java.util.Map (get-features) s))
 
 (defmacro transact!
-  [& forms]
   "Perform graph operations inside a transaction."
+  [& forms]
   `(~transact!* (fn [] ~@forms)))
 
 (defn- retry-transact!*
@@ -135,12 +135,12 @@
           (recur max-retries wait-time-fn (inc try-count) f))))))
 
 (defmacro retry-transact!
-  [max-retries wait-time & forms]
   "Perform graph operations inside a transaction.  The transaction will retry up
   to `max-retries` times.  `wait-time` can be an integer corresponding to the
   number of milliseconds to wait before each try, or it can be a function that
   takes the retry number (starting with 1) and returns the number of
   milliseconds to wait before that retry."
+  [max-retries wait-time & forms]
   `(let [wait-time-fn# (if (ifn? ~wait-time)
                          ~wait-time
                          (constantly ~wait-time))]

--- a/test/archimedes/vertex_test.clj
+++ b/test/archimedes/vertex_test.clj
@@ -79,7 +79,7 @@
     (is (= #{"B" "C"}
            (set (map #(v/get % :name) (v/find-by-kv :age 2)))))))
 
-(deftest test-find-by-kv
+(deftest test-find-by-kv-2
   (g/use-clean-graph!)
   (let [v1 (v/create-with-id! 100 {:age  1
                                    :name "A"})


### PR DESCRIPTION
The change from ^Map to ^java.util.Map type tag is not needed for
Clojure, nor is it harmful for Clojure, but it does help the
pre-release version of the Eastwood Clojure lint tool to avoid
throwing an exception (the cause of which is being investigated at the
Clojure 'spec' level with Clojure developers).

The deftest that had a duplicate name was causing some unit tests
never to run.  All tests still pass after the rename to make them
unique, at least on my dev environment.
