### PR TITLE
Fix #24, support vector as property value

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -15,7 +15,8 @@
                                      [commons-io/commons-io "2.4"]]}
              :1.5    {:dependencies [[org.clojure/clojure "1.5.1"]]}
              :1.7    {:dependencies [[org.clojure/clojure "1.7.0"]]}
-             :master {:dependencies [[org.clojure/clojure "1.8.0-master-SNAPSHOT"]]}}
+             :1.11 {:dependencies [[org.clojure/clojure "1.11.1"]]}
+             :master {:dependencies [[org.clojure/clojure "1.8.0"]]}}
   :aliases {"all" ["with-profile" "dev:dev,1.5:dev,1.7:dev,master"]}
   :repositories {"sonatype" {:url "http://oss.sonatype.org/content/repositories/releases"
                              :snapshots false

--- a/src/clojure/clojurewerkz/archimedes/element.clj
+++ b/src/clojure/clojurewerkz/archimedes/element.clj
@@ -33,7 +33,10 @@
 (defn merge!
   [^Element elem & maps]
   (doseq [d maps]
-    (apply assoc! (cons elem (flatten (into [] d)))))
+    (apply assoc! elem (if (map? d) 
+                         (apply concat (into [] d))
+                         ;; The old code, for when a user passes directly [:k "val", ...x]
+                         (flatten (into [] d)))))
   elem)
 
 (defn dissoc!

--- a/test/clojurewerkz/archimedes/element_test.clj
+++ b/test/clojurewerkz/archimedes/element_test.clj
@@ -33,6 +33,12 @@
     (is (nil? (:a (v/to-map a))))
     (is (nil? (:a (v/to-map c))))))
 
+(deftest test-create-with-properties!
+  (let [g (clean-tinkergraph)
+        a (v/create-with-id!  g 100 {:str "s", :num 1, :vec [1 2] :set #{"a" "b"}})]
+    (is (= {:str "s", :num 1, :vec [1 2] :set #{"a" "b"}} 
+           (select-keys (v/to-map a) [:str :num :vec :set])))))
+
 
 (deftest test-clear!
   (let [g (clean-tinkergraph)


### PR DESCRIPTION
As described in #24, we were unable to store vectors as values in TinkerPop because of flatten.

This replaces the IMO unnecessary `flatten` with the much more, single-level `apply concat`.

I decided to keep the old code for non-map inputs (as those some tests provide) to keep backwards compatibility with any clients using those.